### PR TITLE
[Bugfix] Fix statcast leaderboard using the wrong season param issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ruff
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
           args: 'check'
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
           args: 'format --check'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,6 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           args: 'check'
-      - uses: astral-sh/ruff-action@v3
-        with:
-          args: 'format --check'
 
   build:
     name: Build distribution 📦

--- a/src/baseball_stats_python/statcast/catcher_throwing.py
+++ b/src/baseball_stats_python/statcast/catcher_throwing.py
@@ -43,8 +43,9 @@ def catcher_throwing(
         )
 
     params = {
-        'gameType': game_type,
-        'season': season,
+        'game_type': game_type,
+        'season_start': season,
+        'season_end': season,
         'n': 0,
     }
 

--- a/src/baseball_stats_python/statcast/runner_basestealing.py
+++ b/src/baseball_stats_python/statcast/runner_basestealing.py
@@ -65,7 +65,8 @@ def runner_basestealing(
 
     params = {
         'game_type': game_type,
-        'season': season,
+        'season_start': season,
+        'season_end': season,
         'n': 0,
         'pitch_hand': get_hand_param_str(pitch_hand),
         'prior_pk': get_prior_pk_param_str(prior_pk),


### PR DESCRIPTION
### Description
* The API is using `season_start` and `season_end` to filter `season`. Using `season` directly will cause only return the current season (current is 2024) data.

### How to fix
* Change `season` to `season_start` and `season_end`
```diff
params = {
-   season: season
+   season_start: season,
+   season_end: season
}
```

### Related Issue
* #22 